### PR TITLE
Change command executors from singleton objects to instantiated class

### DIFF
--- a/src/main/java/com/mineinabyss/looty/Looty.kt
+++ b/src/main/java/com/mineinabyss/looty/Looty.kt
@@ -22,7 +22,9 @@ class Looty : JavaPlugin(), LootyAddon {
         logger.info("On enable has been called")
         saveDefaultConfig()
         reloadConfig()
-        LootyCommands
+
+        //Register commands
+        LootyCommands()
 
         registerEvents(
                 InventoryTrackingListener,

--- a/src/main/java/com/mineinabyss/looty/LootyCommands.kt
+++ b/src/main/java/com/mineinabyss/looty/LootyCommands.kt
@@ -16,7 +16,7 @@ import com.mineinabyss.looty.config.LootyTypes
 import com.mineinabyss.looty.ecs.components.ChildItemCache
 
 @ExperimentalCommandDSL
-object LootyCommands : IdofrontCommandExecutor() {
+class LootyCommands : IdofrontCommandExecutor() {
     override val commands = commands(looty) {
         "looty" {
             "reload" {


### PR DESCRIPTION
This prevents the executors from being registered for a command before the plugin has been enabled.