### PR TITLE
add ✓ when timer is "done"

### DIFF
--- a/src/main/java/com/mineinabyss/looty/ecs/systems/CooldownDisplaySystem.kt
+++ b/src/main/java/com/mineinabyss/looty/ecs/systems/CooldownDisplaySystem.kt
@@ -7,6 +7,7 @@ import com.mineinabyss.geary.ecs.entities.parent
 import com.mineinabyss.looty.ecs.components.inventory.SlotType
 import org.bukkit.ChatColor
 import org.bukkit.entity.Player
+import org.bukkit.map.MinecraftFont
 import kotlin.math.roundToInt
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
@@ -41,7 +42,7 @@ object CooldownDisplaySystem : TickingSystem(interval = INTERVAL) {
                         append(displayChar)
                     }
                     append(ChatColor.GRAY)
-                    append(" [$timeLeft]")
+                    if (squaresLeft < 1) (append(ChatColor.BOLD," ✓")) else append(" [$timeLeft]")
                 }
             })
         }


### PR DESCRIPTION
Might be smarter way to do it but it works unless cooldown is immensily long
1 minute cooldown makes it show at 3 seconds left.

should prob do it based on timeLeft, but for really short timers.
If timer is really short however, it will sometimes stop updating at say 110ms left, meaning it wont show