### PR TITLE
Better Recipes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ dependencies {
     compileOnly("com.github.okkero:skedule")
 
     // Shaded
-    implementation("com.mineinabyss:idofront:1.17.1-0.6.23")
+   implementation("com.mineinabyss:idofront:1.17.1-0.6.26")
 }
 
 tasks {

--- a/src/main/java/com/mineinabyss/looty/ecs/components/RegisterRecipeComponent.kt
+++ b/src/main/java/com/mineinabyss/looty/ecs/components/RegisterRecipeComponent.kt
@@ -1,49 +1,16 @@
 package com.mineinabyss.looty.ecs.components
 
 import com.mineinabyss.geary.ecs.api.autoscan.AutoscanComponent
-import com.mineinabyss.geary.ecs.serialization.FlatSerializer
-import com.mineinabyss.geary.ecs.serialization.FlatWrap
-import com.mineinabyss.idofront.serialization.SerializableItemStack
-import com.mineinabyss.idofront.serialization.SerializableRecipeIngredients
+import com.mineinabyss.idofront.serialization.recipes.SerializableRecipeIngredients
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.serializer
-import org.bukkit.NamespacedKey
-import org.bukkit.inventory.ItemStack
-import org.bukkit.inventory.Recipe
-import org.bukkit.inventory.RecipeChoice
-import org.bukkit.inventory.ShapedRecipe
 
-@Serializable(with = RegisterRecipeComponentSerializer::class)
+@Serializable
+@SerialName("looty:recipes")
 @AutoscanComponent
 class RegisterRecipeComponent(
-    override val wrapped: List<SerializableDiscoverableRecipeIngredients>
-) : FlatWrap<List<SerializableDiscoverableRecipeIngredients>>
-
-object RegisterRecipeComponentSerializer :
-    FlatSerializer<RegisterRecipeComponent, List<SerializableDiscoverableRecipeIngredients>>(
-        "looty:recipes", serializer(), { RegisterRecipeComponent(it) }
-    )
-
-/**
- * could extend SerializableRecipeIngredients if it was an open class
- *
- * @see SerializableRecipeIngredients
- */
-@Serializable
-class SerializableDiscoverableRecipeIngredients(
-    val items: Map<String, SerializableItemStack>,
-    val configuration: String,
-    val discoverRecipe: Boolean = false
-) {
-    fun toCraftingRecipe(key: NamespacedKey, result: ItemStack): Recipe {
-        val recipe = ShapedRecipe(key, result)
-
-        recipe.shape(*configuration.replace("|", "").split("\n").toTypedArray())
-
-        items.forEach { (key, ingredient) ->
-            recipe.setIngredient(key[0], RecipeChoice.ExactChoice(ingredient.toItemStack()))
-        }
-
-        return recipe
-    }
-}
+    val recipes: List<SerializableRecipeIngredients>,
+    val discoverRecipes: Boolean = false,
+    val group: String = "",
+    val removeRecipes: List<String> = listOf()
+)

--- a/src/main/java/com/mineinabyss/looty/ecs/systems/ItemRecipeSystem.kt
+++ b/src/main/java/com/mineinabyss/looty/ecs/systems/ItemRecipeSystem.kt
@@ -7,6 +7,7 @@ import com.mineinabyss.idofront.recpies.register
 import com.mineinabyss.looty.LootyFactory
 import com.mineinabyss.looty.ecs.components.LootyType
 import com.mineinabyss.looty.ecs.components.RegisterRecipeComponent
+import org.bukkit.Bukkit
 import org.bukkit.NamespacedKey
 import org.bukkit.event.EventHandler
 import org.bukkit.event.Listener
@@ -22,12 +23,16 @@ class ItemRecipeSystem : TickingSystem(), Listener {
     override fun QueryResult.tick() {
         val result = LootyFactory.createFromPrefab(prefabKey) ?: return
 
-        recipes.wrapped.forEachIndexed { i, recipe ->
+        recipes.removeRecipes.forEach {
+            Bukkit.removeRecipe(NamespacedKey.fromString(it)!!)
+        }
+
+        recipes.recipes.forEachIndexed { i, recipe ->
             @Suppress("DEPRECATION")
             val key = NamespacedKey(prefabKey.plugin, "${prefabKey.name}$i")
             registeredRecipes += key
-            recipe.toCraftingRecipe(key, result).register()
-            if (recipe.discoverRecipe) discoveredRecipes += key
+            recipe.toRecipe(key, result, recipes.group).register()
+            if (recipes.discoverRecipes) discoveredRecipes += key
         }
         entity.remove<RegisterRecipeComponent>()
     }

--- a/src/main/java/com/mineinabyss/looty/ecs/systems/ItemRecipeSystem.kt
+++ b/src/main/java/com/mineinabyss/looty/ecs/systems/ItemRecipeSystem.kt
@@ -3,7 +3,7 @@ package com.mineinabyss.looty.ecs.systems
 import com.mineinabyss.geary.ecs.api.systems.TickingSystem
 import com.mineinabyss.geary.ecs.engine.iteration.QueryResult
 import com.mineinabyss.geary.ecs.prefab.PrefabKey
-import com.mineinabyss.idofront.recpies.register
+import com.mineinabyss.idofront.recipes.register
 import com.mineinabyss.looty.LootyFactory
 import com.mineinabyss.looty.ecs.components.LootyType
 import com.mineinabyss.looty.ecs.components.RegisterRecipeComponent


### PR DESCRIPTION
## relies on https://github.com/MineInAbyss/Idofront/pull/19

Allow for more recipe types to be used from Idofront

```diff
+ Removing recipes
+ Better discover recipe option
```

# Example of new format: 

```yml
- !<looty:recipes>
  discoverRecipes: true
  removeRecipes:
    - minecraft:netherite_hoe_smithing
  recipes:
    - !<shaped>
      items:
        M:
          type: NETHERITE_INGOT
        S:
          type: STICK
      configuration: |-
        | MM|
        | SM|
        |S  |
```